### PR TITLE
Declare parameters in unit tests to conform to Dashing.

### DIFF
--- a/aws_ros2_common/test/client_configuration_provider_test.cpp
+++ b/aws_ros2_common/test/client_configuration_provider_test.cpp
@@ -30,14 +30,19 @@
 void initialize_node_and_config(rclcpp::Node::SharedPtr node, Aws::Client::ClientConfiguration &config)
 {
     rclcpp::Parameter region(CLIENT_CONFIG_PREFIX ".region", "uk-north-20");
+    node->declare_parameter(CLIENT_CONFIG_PREFIX ".region");
     config.region = "uk-north-20";
     rclcpp::Parameter proxyPort(CLIENT_CONFIG_PREFIX ".proxy_port", 787);
+    node->declare_parameter(CLIENT_CONFIG_PREFIX ".proxy_port");
     config.proxyPort = 787;
     rclcpp::Parameter connectTimeoutMs(CLIENT_CONFIG_PREFIX ".connect_timeout_ms", 511111);
+    node->declare_parameter(CLIENT_CONFIG_PREFIX ".connect_timeout_ms");
     config.connectTimeoutMs = 511111;
     rclcpp::Parameter verifySSL(CLIENT_CONFIG_PREFIX ".verify_SSL", true);
+    node->declare_parameter(CLIENT_CONFIG_PREFIX ".verify_SSL");
     config.verifySSL = true;
     rclcpp::Parameter followRedirects(CLIENT_CONFIG_PREFIX ".follow_redirects", true);
+    node->declare_parameter(CLIENT_CONFIG_PREFIX ".follow_redirects");
     config.followRedirects = true;
     node->set_parameters({region, proxyPort, connectTimeoutMs, verifySSL, followRedirects});
 }

--- a/aws_ros2_common/test/parameter_reader_test.cpp
+++ b/aws_ros2_common/test/parameter_reader_test.cpp
@@ -34,6 +34,7 @@ TEST(ParameterReader, parameterPathResolution)
 {
     Aws::Client::ClientConfiguration prepared_config;
     auto dummy_node = rclcpp::Node::make_shared("_");
+    dummy_node->declare_parameter(PARAM_READER_TEST__PARAM_PREFIX "." PARAM_READER_TEST__PARAM_KEY);
     auto parameter_reader = std::make_shared<Aws::Client::Ros2NodeParameterReader>(dummy_node);
     dummy_node->set_parameters(
         {rclcpp::Parameter(PARAM_READER_TEST__PARAM_PREFIX "." PARAM_READER_TEST__PARAM_KEY, PARAM_READER_TEST__PARAM_VALUE)}


### PR DESCRIPTION
Since Dashing, parameters need to be declared by calling "declare_parameter".
(Checks are expected to fail until we merge https://github.com/aws-robotics/travis-scripts/pull/42)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
