### PR TITLE
Guard test targets with if(BUILD_TESTING)

### DIFF
--- a/aws_ros2_common/CMakeLists.txt
+++ b/aws_ros2_common/CMakeLists.txt
@@ -6,7 +6,6 @@ add_compile_options(-std=c++14)
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(aws_common REQUIRED)
-find_package(ament_cmake_gtest REQUIRED)
 
 if(AWSSDK_FOUND)
   set(SERVICE core)
@@ -33,26 +32,30 @@ install(
     DESTINATION include/
 )
 
-ament_add_gtest(test_configuration_provider test/client_configuration_provider_test.cpp)
-target_link_libraries(test_configuration_provider
-    ${aws_common_LIBRARIES}
-    ${PROJECT_NAME}
-    ${rclcpp_LIBRARIES}
-)
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  
+  ament_add_gtest(test_configuration_provider test/client_configuration_provider_test.cpp)
+  target_link_libraries(test_configuration_provider
+      ${aws_common_LIBRARIES}
+      ${PROJECT_NAME}
+      ${rclcpp_LIBRARIES}
+  )
 
-ament_add_gtest(test_logger test/sdk_utils/logging/aws_ros_logger_test.cpp)
-target_link_libraries(test_logger
-    ${aws_common_LIBRARIES}
-    ${PROJECT_NAME}
-    ${rclcpp_LIBRARIES}
-)
+  ament_add_gtest(test_logger test/sdk_utils/logging/aws_ros_logger_test.cpp)
+  target_link_libraries(test_logger
+      ${aws_common_LIBRARIES}
+      ${PROJECT_NAME}
+      ${rclcpp_LIBRARIES}
+  )
 
-ament_add_gtest(test_parameter_reader test/parameter_reader_test.cpp)
-target_link_libraries(test_parameter_reader
-    ${aws_common_LIBRARIES}
-    ${PROJECT_NAME}
-    ${rclcpp_LIBRARIES}
-)
+  ament_add_gtest(test_parameter_reader test/parameter_reader_test.cpp)
+  target_link_libraries(test_parameter_reader
+      ${aws_common_LIBRARIES}
+      ${PROJECT_NAME}
+      ${rclcpp_LIBRARIES}
+  )
+endif()
 
 ament_export_libraries(${PROJECT_NAME})
 ament_export_include_directories("include")


### PR DESCRIPTION
Due to http://build.ros2.org/job/Ddev__aws_ros2_common__ubuntu_bionic_amd64/1/console
Fix inspired by https://github.com/ros2/rclcpp/blob/master/rclcpp/CMakeLists.txt#L142
Tested at https://travis-ci.org/AAlon/ROS2Prerelease/builds/582181196

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
