### PR TITLE
Fix linting issues found by clang-tidy 6.0

### DIFF
--- a/aws_ros2_common/include/aws_ros2_common/sdk_utils/logging/aws_ros_logger.h
+++ b/aws_ros2_common/include/aws_ros2_common/sdk_utils/logging/aws_ros_logger.h
@@ -20,7 +20,9 @@
 #include <rclcpp/rclcpp.hpp>
 #include <string>
 
-namespace Aws { namespace Utils { namespace Logging {
+namespace Aws {
+namespace Utils {
+namespace Logging {
 
 class AWSROSLogger : public AWSLogSystem
 {
@@ -32,7 +34,7 @@ public:
      * @param node
      */
     explicit AWSROSLogger(Aws::Utils::Logging::LogLevel log_level, std::weak_ptr<rclcpp::Node> node);
-    virtual ~AWSROSLogger();
+    ~AWSROSLogger() override;
 
 protected:
 
@@ -47,6 +49,8 @@ private:
     std::weak_ptr<rclcpp::Node> node_;
 };
 
-}}}
+}  // namespace Logging
+}  // namespace Utils
+}  // namespace Aws
 
 #endif  // AWS_COMMON_INCLUDE_SDK_UTILS_LOGGING_AWSROSLOGGER_H_

--- a/aws_ros2_common/include/aws_ros2_common/sdk_utils/logging/aws_ros_logger.h
+++ b/aws_ros2_common/include/aws_ros2_common/sdk_utils/logging/aws_ros_logger.h
@@ -34,6 +34,8 @@ public:
      * @param node
      */
     explicit AWSROSLogger(Aws::Utils::Logging::LogLevel log_level, std::weak_ptr<rclcpp::Node> node);
+    AWSROSLogger(AWSROSLogger const &) = delete;              // Do not allow copy constructor
+    AWSROSLogger & operator=(AWSROSLogger const &) = delete;  // Do not allow assignment operator
     ~AWSROSLogger() override;
 
 protected:

--- a/aws_ros2_common/include/aws_ros2_common/sdk_utils/ros2_node_parameter_reader.h
+++ b/aws_ros2_common/include/aws_ros2_common/sdk_utils/ros2_node_parameter_reader.h
@@ -26,7 +26,7 @@ namespace Client {
 class Ros2NodeParameterReader : public ParameterReaderInterface
 {
 public:
-    Ros2NodeParameterReader(const std::weak_ptr<rclcpp::Node> node) : node_(node) {}
+    explicit Ros2NodeParameterReader(const std::weak_ptr<rclcpp::Node>& node) : node_(node) {}
 
     AwsError ReadParam(const ParameterPath & param_path, std::vector<std::string> & out) const override;
     AwsError ReadParam(const ParameterPath & param_path, double & out) const override;
@@ -40,5 +40,7 @@ private:
     const std::weak_ptr<rclcpp::Node> node_;
 };
 
-} /* namespace */
-} /* namespace */
+}  // namespace Client
+
+}  // namespace Aws
+

--- a/aws_ros2_common/src/sdk_utils/logging/aws_ros_logger.cpp
+++ b/aws_ros2_common/src/sdk_utils/logging/aws_ros_logger.cpp
@@ -14,14 +14,18 @@
  */
 
 #include <rclcpp/rclcpp.hpp>
+#include <utility>
 #include <aws_ros2_common/sdk_utils/logging/aws_ros_logger.h>
 
-using namespace Aws::Utils::Logging;
 
-AWSROSLogger::AWSROSLogger(Aws::Utils::Logging::LogLevel log_level = LogLevel::Trace, std::weak_ptr<rclcpp::Node> node = std::weak_ptr<rclcpp::Node>{})
-    : node_(node), AWSLogSystem(log_level) {}
+namespace Aws {
+namespace Utils {
+namespace Logging {
 
-AWSROSLogger::~AWSROSLogger() {}
+AWSROSLogger::AWSROSLogger(Aws::Utils::Logging::LogLevel log_level, std::weak_ptr<rclcpp::Node> node)
+    : node_(std::move(node)), AWSLogSystem(log_level) {}
+
+AWSROSLogger::~AWSROSLogger() = default;
 
 void
 AWSROSLogger::LogInfo(const char* tag, const std::string& message) {
@@ -65,3 +69,7 @@ AWSROSLogger::LogFatal(const char* tag, const std::string& message) {
         RCLCPP_FATAL(node->get_logger(), "[%s] %s", tag, message.c_str());
     }
 }
+
+}  // namespace Logging
+}  // namespace Utils
+}  // namespace Aws

--- a/aws_ros2_common/src/sdk_utils/ros2_node_parameter_reader.cpp
+++ b/aws_ros2_common/src/sdk_utils/ros2_node_parameter_reader.cpp
@@ -29,7 +29,7 @@ constexpr char kNodeNsSeparator = '/';
  */
 template <class T>
 static AwsError ReadParamTemplate(const ParameterPath & param_path,
-                                  std::weak_ptr<rclcpp::Node> node,
+                                  const std::weak_ptr<rclcpp::Node>& node,
                                   T & out) {
     std::string name = param_path.get_resolved_path(kNodeNsSeparator, kParameterNsSeparator);
     if (std::string::npos != name.find(kNodeNsSeparator)) {
@@ -77,9 +77,11 @@ AwsError Ros2NodeParameterReader::ReadParam(const ParameterPath & param_path, Aw
     return result;
 }
 
-AwsError Ros2NodeParameterReader::ReadParam(const ParameterPath & param_path, std::map<std::string, std::string> & out) const {
+AwsError Ros2NodeParameterReader::ReadParam(const ParameterPath &  /*param_path*/, std::map<std::string, std::string> &  /*out*/) const {
     return AWS_ERR_NOT_SUPPORTED;
 }
 
-} /* namespace */
-} /* namespace */
+}  // namespace Client
+
+}  // namespace Aws
+

--- a/aws_ros2_common/test/client_configuration_provider_test.cpp
+++ b/aws_ros2_common/test/client_configuration_provider_test.cpp
@@ -27,7 +27,7 @@
  * @param node
  * @param config
  */
-void initialize_node_and_config(rclcpp::Node::SharedPtr node, Aws::Client::ClientConfiguration &config)
+void initialize_node_and_config(const rclcpp::Node::SharedPtr& node, Aws::Client::ClientConfiguration &config)
 {
     rclcpp::Parameter region(CLIENT_CONFIG_PREFIX ".region", "uk-north-20");
     node->declare_parameter(CLIENT_CONFIG_PREFIX ".region");

--- a/aws_ros2_common/test/sdk_utils/logging/aws_ros_logger_test.cpp
+++ b/aws_ros2_common/test/sdk_utils/logging/aws_ros_logger_test.cpp
@@ -25,11 +25,11 @@
 #include <gtest/gtest.h>
 #include <aws_ros2_common/sdk_utils/logging/aws_ros_logger.h>
 #include <aws/core/utils/logging/LogMacros.h>
-#include <stdio.h>
+#include <cstdio>
 
 using namespace Aws::Utils::Logging;
 
-typedef std::shared_ptr<AWSLogSystem> aws_logger_t;
+using aws_logger_t = std::shared_ptr<AWSLogSystem>;
 
 TEST(AWSROSLoggerTest, testStderr) {
     auto dummy_node = rclcpp::Node::make_shared("my_node_name");


### PR DESCRIPTION
*Description of changes:*

Fixing linting issues found by `clang-tidy` 6.0, without introducing public API changes (there may be ABI changes though).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.